### PR TITLE
use .clear() for String instead of assignment operator

### DIFF
--- a/firmware/LedPanelWiFi_v1.14/web.ino
+++ b/firmware/LedPanelWiFi_v1.14/web.ino
@@ -391,11 +391,9 @@ void processOutQueueW() {
       }
     }
     
-    // Очищаем строку в очереди. Использовать .clear() нельзя, поскольку он не только обнуляет содержимое строки, но и очищает (освобождает) память
-    // ранее занимаемую строкой. Если память не освобождать, то в следующий раз запись туда нового значения строки будет повторно использовать уже выделенную память.
-    // Если память, занимаемую строкой освобождать - она будет выделена заново в Heap, что приведет к его фрагментации, а нам это не нужно
-    outWQueue[outWQueueReadIdx] = "";  
-    tpcWQueue[outWQueueReadIdx] = "";
+    // Очищаем строку в очереди
+    outWQueue[outWQueueReadIdx].clear();  
+    tpcWQueue[outWQueueReadIdx].clear();
     outWQueueReadIdx++;
     
     if (outWQueueReadIdx >= QSIZE_OUT) outWQueueReadIdx = 0;


### PR DESCRIPTION
> Использовать .clear() нельзя, поскольку он не только обнуляет содержимое строки, но и очищает (освобождает) память

это неверно. `String.clear()` только обнулят длинну строки в буфере, деаллокации памяти не происходит. Если нужно именно такое поведение, то `.clear()` использовать предпочтительнее оператора присвоения

https://github.com/espressif/arduino-esp32/blob/51cb927712e512664a0a0f7b1219fdc18e11b857/cores/esp32/WString.h#L94-L96
