### PR TITLE
профиль сборки платформио под 8266

### DIFF
--- a/libraries/DFPlayer_Mini_Mp3_by_Makuna/library.json
+++ b/libraries/DFPlayer_Mini_Mp3_by_Makuna/library.json
@@ -9,10 +9,7 @@
   },
   "version": "1.1.1",
   "frameworks": "arduino",
-  "platforms": "*",
-  "dependencies": [
-    {
-    }
+  "platforms": "*"
   ]
 }
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,6 +21,22 @@ lib_ignore =
   DFMiniMp3
   LittleFS_esp32
 
+[esp8266_base]
+framework = arduino
+platform = espressif8266
+board_build.filesystem = littlefs
+monitor_speed = 115200
+monitor_filters = esp8266_exception_decoder
+lib_ignore =
+  LittleFS_esp32
+  AsyncTCP
+  DFMiniMp3
+
+
 [env:esp32]
 extends = esp32_base
 board = wemos_d1_mini32
+
+[env:esp8266]
+extends = esp8266_base
+board = d1_mini


### PR DESCRIPTION
добавил для проверки сборки. Используется актуальное ядро 8266. Практическую работу с матрицей не проверял